### PR TITLE
Load cl.el at compile time for using lexical-let

### DIFF
--- a/helm-ad.el
+++ b/helm-ad.el
@@ -31,6 +31,9 @@
 (require 'dash)
 (require 'helm)
 
+(eval-when-compile
+  (require 'cl))
+
 (defvar helm-ad-action-function 'insert)
 (defvar helm-source-ad-action-alist nil)
 (defvar helm-source-ad-params-contact nil)


### PR DESCRIPTION
This fixes following byte-compile warnings.

```
In helm-ad-dsget-function:
helm-ad.el:65:36:Warning: ‘(cmd cmd)’ is a malformed function

In helm-source-ad-command-candidates-function:
helm-ad.el:87:52:Warning: ‘(cmd cmd)’ is a malformed function

In helm-source-ad-command:
helm-ad.el:95:32:Warning: ‘(cmd cmd)’ is a malformed function

In end of data:
helm-ad.el:139:1:Warning: the following functions are not known to be defined: lexical-let,
    prop
```
